### PR TITLE
Fixed a small typo, missing two forward slashes after http colon

### DIFF
--- a/website/docs/00-Preface/00.03-Supporting-Materials.md
+++ b/website/docs/00-Preface/00.03-Supporting-Materials.md
@@ -3,19 +3,19 @@
 Supporting materials for this text can be found on the textbook website:
 
  > [https://problemsolvingwithpython.com](https://problemsolvingwithpython.com)
-        
+
 The textbook website contains all of the text in web format. Code examples and Jupyter notebooks for the text can be found in the GitHub repository for the book:
 
- > [https:github.com/ProfessorKazarinoff/Problem-Solving-with-Python](https:github.com/ProfessorKazarinoff/Problem-Solving-with-Python)
-    
+ > [https://github.com/ProfessorKazarinoff/Problem-Solving-with-Python](https//:github.com/ProfessorKazarinoff/Problem-Solving-with-Python)
+
 Live notebooks, where code examples found in the text can be run without installing any software, are available at:
 
  > [https://mybinder.org/v2/gh/ProfessorKazarinoff/Problem-Solving-with-Python/master](https://mybinder.org/v2/gh/ProfessorKazarinoff/Problem-Solving-with-Python/master)
-    
-If you are an instructor and using this book in a course with students- please send me an email using your school email address. In the email, include the course you are teaching and the term, approximate enrollment, and a link to the course listing on your school website. 
+
+If you are an instructor and using this book in a course with students- please send me an email using your school email address. In the email, include the course you are teaching and the term, approximate enrollment, and a link to the course listing on your school website.
 
  > peter.kazarinoff@problemsolvingwithpython.com
 
 I am happy to reply with a solution key for the end of chapter review problems as well as quiz and exam question banks.
- 
+
 

--- a/website/docs/00-Preface/00.03-Supporting-Materials.md
+++ b/website/docs/00-Preface/00.03-Supporting-Materials.md
@@ -6,7 +6,7 @@ Supporting materials for this text can be found on the textbook website:
 
 The textbook website contains all of the text in web format. Code examples and Jupyter notebooks for the text can be found in the GitHub repository for the book:
 
- > [https://github.com/ProfessorKazarinoff/Problem-Solving-with-Python](https//:github.com/ProfessorKazarinoff/Problem-Solving-with-Python)
+ > [https://github.com/ProfessorKazarinoff/Problem-Solving-with-Python](https://github.com/ProfessorKazarinoff/Problem-Solving-with-Python)
 
 Live notebooks, where code examples found in the text can be run without installing any software, are available at:
 


### PR DESCRIPTION
Hi! I noticed a very small typo on the website: two missing slashes after `http:`.

Hope I fixed the typo in the right place. I am not entirely if this is the file where the other formats, like PDF for example, originate from.

I edited the file with vim and I think it removed extra space characters on empty lines (lines 6, 10, 14, 20). I hope this is not a problem.